### PR TITLE
pymc3 deprecated nuts_kwargs

### DIFF
--- a/best/model.py
+++ b/best/model.py
@@ -66,7 +66,7 @@ class BestModel(ABC):
         """
 
         kwargs['tune'] = kwargs.get('tune', 1000)
-        kwargs['nuts_kwargs'] = kwargs.get('nuts_kwargs', {'target_accept': 0.90})
+        kwargs['target_accept'] = kwargs.get('nuts_kwargs', {'target_accept': 0.90})['target_accept']
         max_rounds = 2
         for r in range(max_rounds):
             with self.model:


### PR DESCRIPTION
allows the nuts_kwargs parameter to be passed through kwargs